### PR TITLE
Issue/29 add task tags

### DIFF
--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -1,9 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getAllTags } from "@/lib/data/tags";
 
 // 全てのタグを取得（認証ユーザーのもののみ）
-export async function GET(request: NextRequest) {
+export async function GET() {
   try {
     const supabase = await createClient();
     const {

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getAllTags } from "@/lib/data/tags";
+
+// 全てのタグを取得（認証ユーザーのもののみ）
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const tags = await getAllTags(user.id);
+    return NextResponse.json(tags);
+  } catch (error) {
+    console.error("Error fetching all tags:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch tags" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/users/[userId]/tags/route.ts
+++ b/app/api/users/[userId]/tags/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getAllTags } from "@/lib/data/tags";
+
+// ユーザーの全てのタグを取得
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  try {
+    const supabase = await createClient();
+    const { userId } = await params;
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // ユーザーIDの確認
+    if (user.id !== userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const tags = await getAllTags(userId);
+    return NextResponse.json(tags);
+  } catch (error) {
+    console.error("Error fetching user tags:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch tags" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/users/[userId]/tasks/[taskId]/tags/route.ts
+++ b/app/api/users/[userId]/tasks/[taskId]/tags/route.ts
@@ -1,0 +1,166 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+import { 
+  getTagsByTaskId,
+  addTagToTask,
+  removeTagFromTask
+} from "@/lib/data/taskTags";
+import { getAllTags, createTag } from "@/lib/data/tags";
+
+// タスクに紐づくタグ一覧を取得
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string; taskId: string }> }
+) {
+  try {
+    const supabase = await createClient();
+    const { userId, taskId } = await params;
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // ユーザーIDの確認
+    if (user.id !== userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // タスクの所有者確認
+    const { data: task } = await supabase
+      .from("tasks")
+      .select("user_id")
+      .eq("id", taskId)
+      .single();
+
+    if (!task || task.user_id !== userId) {
+      return NextResponse.json({ error: "Task not found or access denied" }, { status: 404 });
+    }
+
+    const tags = await getTagsByTaskId(taskId);
+    return NextResponse.json(tags);
+  } catch (error) {
+    console.error("Error fetching task tags:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch task tags" },
+      { status: 500 }
+    );
+  }
+}
+
+// タスクにタグを追加
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string; taskId: string }> }
+) {
+  try {
+    const supabase = await createClient();
+    const { userId, taskId } = await params;
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // ユーザーIDの確認
+    if (user.id !== userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // タスクの所有者確認
+    const { data: task } = await supabase
+      .from("tasks")
+      .select("user_id")
+      .eq("id", taskId)
+      .single();
+
+    if (!task || task.user_id !== userId) {
+      return NextResponse.json({ error: "Task not found or access denied" }, { status: 404 });
+    }
+
+    const { tagId, tagName } = await request.json();
+
+    let finalTagId = tagId;
+
+    // 新しいタグを作成する場合
+    if (!tagId && tagName) {
+      const newTag = await createTag(tagName, userId);
+      finalTagId = newTag.id;
+    }
+
+    if (!finalTagId) {
+      return NextResponse.json(
+        { error: "Tag ID or tag name is required" },
+        { status: 400 }
+      );
+    }
+
+    await addTagToTask(taskId, finalTagId);
+    return NextResponse.json({ message: "Tag added successfully" }, { status: 201 });
+  } catch (error) {
+    console.error("Error adding tag to task:", error);
+    return NextResponse.json(
+      { error: "Failed to add tag to task" },
+      { status: 500 }
+    );
+  }
+}
+
+// タスクからタグを削除
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string; taskId: string }> }
+) {
+  try {
+    const supabase = await createClient();
+    const { userId, taskId } = await params;
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // ユーザーIDの確認
+    if (user.id !== userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // タスクの所有者確認
+    const { data: task } = await supabase
+      .from("tasks")
+      .select("user_id")
+      .eq("id", taskId)
+      .single();
+
+    if (!task || task.user_id !== userId) {
+      return NextResponse.json({ error: "Task not found or access denied" }, { status: 404 });
+    }
+
+    const { tagId } = await request.json();
+
+    if (!tagId) {
+      return NextResponse.json(
+        { error: "Tag ID is required" },
+        { status: 400 }
+      );
+    }
+
+    await removeTagFromTask(taskId, tagId);
+    return NextResponse.json({ message: "Tag removed successfully" });
+  } catch (error) {
+    console.error("Error removing tag from task:", error);
+    return NextResponse.json(
+      { error: "Failed to remove tag from task" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/users/[userId]/tasks/[taskId]/tags/route.ts
+++ b/app/api/users/[userId]/tasks/[taskId]/tags/route.ts
@@ -5,7 +5,7 @@ import {
   addTagToTask,
   removeTagFromTask
 } from "@/lib/data/taskTags";
-import { getAllTags, createTag } from "@/lib/data/tags";
+import { createTag } from "@/lib/data/tags";
 
 // タスクに紐づくタグ一覧を取得
 export async function GET(

--- a/app/users/[user_id]/tasks/[id]/page.tsx
+++ b/app/users/[user_id]/tasks/[id]/page.tsx
@@ -3,6 +3,9 @@ import { notFound } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { ArrowLeft } from "lucide-react";
 import { getTaskById } from "@/lib/data/tasks";
+import { getTagsByTaskId } from "@/lib/data/taskTags";
+import { TagsSection } from "@/components/tags/tags-section";
+import { createClient } from "@/lib/supabase/server";
 
 const priorityMap: {
   [key: string]: { label: string; className: string };
@@ -24,6 +27,14 @@ export default async function TaskDetailPage({
   if (!task) {
     notFound();
   }
+
+  // 現在のユーザーを取得
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  const isOwner = user?.id === user_id;
+
+  // タグを取得
+  const tags = await getTagsByTaskId(id);
 
   return (
     <div className="space-y-6">
@@ -66,6 +77,14 @@ export default async function TaskDetailPage({
           </p>
         </div>
       )}
+
+      {/* タグセクション */}
+      <TagsSection
+        taskId={id}
+        userId={user_id}
+        isOwner={isOwner}
+        initialTags={tags}
+      />
     </div>
   );
 }

--- a/components/tags/tag-editor.tsx
+++ b/components/tags/tag-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Tag } from "@/lib/definitions";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -23,7 +23,7 @@ export function TagEditor({ taskId, userId, onTagsChange }: TagEditorProps) {
   const [isLoading, setIsLoading] = useState(false);
 
   // 現在のタグを取得
-  const fetchCurrentTags = async () => {
+  const fetchCurrentTags = useCallback(async () => {
     try {
       const response = await fetch(`/api/users/${userId}/tasks/${taskId}/tags`);
       if (!response.ok) throw new Error("Failed to fetch tags");
@@ -34,10 +34,10 @@ export function TagEditor({ taskId, userId, onTagsChange }: TagEditorProps) {
       console.error("Error fetching tags:", error);
       toast.error("タグの取得に失敗しました");
     }
-  };
+  }, [userId, taskId, onTagsChange]); // ← toast を依存配列から除外
 
   // 全てのタグを取得
-  const fetchAllTags = async () => {
+  const fetchAllTags = useCallback(async () => {
     try {
       const response = await fetch(`/api/users/${userId}/tags`);
       if (!response.ok) throw new Error("Failed to fetch all tags");
@@ -46,12 +46,12 @@ export function TagEditor({ taskId, userId, onTagsChange }: TagEditorProps) {
     } catch (error) {
       console.error("Error fetching all tags:", error);
     }
-  };
+  }, [userId]);
 
   useEffect(() => {
     fetchCurrentTags();
     fetchAllTags();
-  }, [taskId, userId]);
+  }, [fetchCurrentTags, fetchAllTags]);
 
   // 新しいタグを作成して追加
   const handleCreateAndAddTag = async () => {

--- a/components/tags/tag-editor.tsx
+++ b/components/tags/tag-editor.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Tag } from "@/lib/definitions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Plus, X } from "lucide-react";
+import { toast } from "sonner";
+
+type TagEditorProps = {
+  taskId: string;
+  userId: string;
+  onTagsChange?: (tags: Tag[]) => void;
+};
+
+export function TagEditor({ taskId, userId, onTagsChange }: TagEditorProps) {
+  const [currentTags, setCurrentTags] = useState<Tag[]>([]);
+  const [allTags, setAllTags] = useState<Tag[]>([]);
+  const [newTagName, setNewTagName] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  // 現在のタグを取得
+  const fetchCurrentTags = async () => {
+    try {
+      const response = await fetch(`/api/users/${userId}/tasks/${taskId}/tags`);
+      if (!response.ok) throw new Error("Failed to fetch tags");
+      const tags = await response.json();
+      setCurrentTags(tags);
+      onTagsChange?.(tags);
+    } catch (error) {
+      console.error("Error fetching tags:", error);
+      toast.error("タグの取得に失敗しました");
+    }
+  };
+
+  // 全てのタグを取得
+  const fetchAllTags = async () => {
+    try {
+      const response = await fetch(`/api/users/${userId}/tags`);
+      if (!response.ok) throw new Error("Failed to fetch all tags");
+      const tags = await response.json();
+      setAllTags(tags);
+    } catch (error) {
+      console.error("Error fetching all tags:", error);
+    }
+  };
+
+  useEffect(() => {
+    fetchCurrentTags();
+    fetchAllTags();
+  }, [taskId, userId]);
+
+  // 新しいタグを作成して追加
+  const handleCreateAndAddTag = async () => {
+    if (!newTagName.trim()) {
+      toast.error("タグ名を入力してください");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const response = await fetch(`/api/users/${userId}/tasks/${taskId}/tags`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tagName: newTagName.trim() }),
+      });
+
+      if (!response.ok) throw new Error("Failed to create tag");
+
+      setNewTagName("");
+      await fetchCurrentTags();
+      await fetchAllTags();
+      toast.success("タグを作成・追加しました");
+    } catch (error) {
+      console.error("Error creating tag:", error);
+      toast.error("タグの作成に失敗しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 既存のタグを追加
+  const handleAddExistingTag = async (tagId: string) => {
+    setIsLoading(true);
+    try {
+      const response = await fetch(`/api/users/${userId}/tasks/${taskId}/tags`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tagId }),
+      });
+
+      if (!response.ok) throw new Error("Failed to add tag");
+
+      await fetchCurrentTags();
+      toast.success("タグを追加しました");
+    } catch (error) {
+      console.error("Error adding tag:", error);
+      toast.error("タグの追加に失敗しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // タグを削除
+  const handleRemoveTag = async (tagId: string) => {
+    setIsLoading(true);
+    try {
+      const response = await fetch(`/api/users/${userId}/tasks/${taskId}/tags`, {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tagId }),
+      });
+
+      if (!response.ok) throw new Error("Failed to remove tag");
+
+      await fetchCurrentTags();
+      toast.success("タグを削除しました");
+    } catch (error) {
+      console.error("Error removing tag:", error);
+      toast.error("タグの削除に失敗しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 現在のタグIDのセット
+  const currentTagIds = new Set(currentTags.map(tag => tag.id));
+
+  // 追加可能なタグ（現在のタグに含まれていないもの）
+  const availableTags = allTags.filter(tag => !currentTagIds.has(tag.id));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">タグ管理</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* 現在のタグ */}
+        <div>
+          <Label className="text-sm font-medium">現在のタグ</Label>
+          <div className="mt-2">
+            {currentTags.length === 0 ? (
+              <div className="text-sm text-muted-foreground">
+                タグがありません
+              </div>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {currentTags.map((tag) => (
+                  <Badge key={tag.id} variant="secondary" className="flex items-center gap-1">
+                    <span>{tag.name}</span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-auto p-0 hover:bg-transparent"
+                      onClick={() => handleRemoveTag(tag.id)}
+                      disabled={isLoading}
+                    >
+                      <X className="h-3 w-3" />
+                    </Button>
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* 新しいタグを作成 */}
+        <div>
+          <Label className="text-sm font-medium">新しいタグを作成</Label>
+          <div className="flex gap-2 mt-2">
+            <Input
+              value={newTagName}
+              onChange={(e) => setNewTagName(e.target.value)}
+              placeholder="タグ名を入力..."
+              onKeyPress={(e) => e.key === "Enter" && handleCreateAndAddTag()}
+            />
+            <Button
+              onClick={handleCreateAndAddTag}
+              disabled={isLoading || !newTagName.trim()}
+              size="sm"
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+
+        {/* 既存のタグから選択 */}
+        {availableTags.length > 0 && (
+          <div>
+            <Label className="text-sm font-medium">既存のタグから選択</Label>
+            <div className="flex flex-wrap gap-2 mt-2">
+              {availableTags.map((tag) => (
+                <Badge
+                  key={tag.id}
+                  variant="outline"
+                  className="cursor-pointer hover:bg-secondary"
+                  onClick={() => handleAddExistingTag(tag.id)}
+                >
+                  <Plus className="h-3 w-3 mr-1" />
+                  {tag.name}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/tags/tag-list.tsx
+++ b/components/tags/tag-list.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Tag } from "@/lib/definitions";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
+
+type TagListProps = {
+  tags: Tag[];
+  onRemoveTag?: (tagId: string) => void;
+  showRemoveButton?: boolean;
+};
+
+export function TagList({ tags, onRemoveTag, showRemoveButton = false }: TagListProps) {
+  if (tags.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        タグがありません
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {tags.map((tag) => (
+        <Badge key={tag.id} variant="secondary" className="flex items-center gap-1">
+          <span>{tag.name}</span>
+          {showRemoveButton && onRemoveTag && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-auto p-0 hover:bg-transparent"
+              onClick={() => onRemoveTag(tag.id)}
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          )}
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/components/tags/tags-section.tsx
+++ b/components/tags/tags-section.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Tag } from "@/lib/definitions";
+import { TagList } from "./tag-list";
+import { TagEditor } from "./tag-editor";
+
+type TagsSectionProps = {
+  taskId: string;
+  userId: string;
+  isOwner: boolean;
+  initialTags: Tag[];
+};
+
+export function TagsSection({ taskId, userId, isOwner, initialTags }: TagsSectionProps) {
+  const [tags, setTags] = useState<Tag[]>(initialTags);
+
+  const handleTagsChange = (newTags: Tag[]) => {
+    setTags(newTags);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold mb-2">タグ</h2>
+        <TagList tags={tags} />
+      </div>
+      
+      {/* タグエディター（タスクの所有者のみ表示） */}
+      {isOwner && (
+        <TagEditor
+          taskId={taskId}
+          userId={userId}
+          onTagsChange={handleTagsChange}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/tags/tags-section.tsx
+++ b/components/tags/tags-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Tag } from "@/lib/definitions";
 import { TagList } from "./tag-list";
 import { TagEditor } from "./tag-editor";

--- a/components/tasks/task-content.tsx
+++ b/components/tasks/task-content.tsx
@@ -4,7 +4,7 @@ import { Input } from "@/components/ui/input";
 import TasksTable from "@/components/tasks/tasks-table";
 import { PlusCircle, ArrowLeft } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
-import { getTasksByUserId } from "@/lib/data/tasks";
+import { getTasksWithTagsByUserId } from "@/lib/data/tasks";
 
 export async function TaskContent({ userId }: { userId: string }) {
   const supabase = await createClient();
@@ -19,7 +19,7 @@ export async function TaskContent({ userId }: { userId: string }) {
     data: { user: authUser },
   } = await supabase.auth.getUser();
 
-  const tasks = await getTasksByUserId(userId);
+  const tasks = await getTasksWithTagsByUserId(userId);
 
   return (
     <div className="space-y-6">

--- a/components/tasks/tasks-table.tsx
+++ b/components/tasks/tasks-table.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { Task } from "@/lib/definitions";
+import { Task, TaskWithTags } from "@/lib/definitions";
 import { User } from "@supabase/supabase-js";
+import { TagList } from "@/components/tags/tag-list";
 import {
   Table,
   TableBody,
@@ -36,12 +37,12 @@ export default function TasksTable({
   userId,
   authUser,
 }: {
-  tasks: Task[];
+  tasks: TaskWithTags[];
   userId: string;
   authUser: User | null;
 }) {
   console.log("[TasksTable] received userId:", userId);
-  const [tasks, setTasks] = useState<Task[]>(initialTasks);
+  const [tasks, setTasks] = useState<TaskWithTags[]>(initialTasks);
 
   if (!userId) {
     return null; // or a loading indicator
@@ -100,6 +101,7 @@ export default function TasksTable({
           <TableRow>
             <TableHead className="w-[50px]"></TableHead>
             <TableHead>タスク名</TableHead>
+            <TableHead>タグ</TableHead>
             <TableHead>詳細</TableHead>
             <TableHead className="w-[100px]">優先度</TableHead>
             <TableHead className="w-[150px]">期限日</TableHead>
@@ -124,6 +126,9 @@ export default function TasksTable({
                 <Link href={`/users/${userId}/tasks/${task.id}`}>
                   {task.title}
                 </Link>
+              </TableCell>
+              <TableCell>
+                <TagList tags={task.tags || []} />
               </TableCell>
               <TableCell>
                 {task.detail?.substring(0, 30)}

--- a/components/tasks/tasks-table.tsx
+++ b/components/tasks/tasks-table.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { Task, TaskWithTags } from "@/lib/definitions";
+import { TaskWithTags } from "@/lib/definitions";
 import { User } from "@supabase/supabase-js";
 import { TagList } from "@/components/tags/tag-list";
 import {

--- a/lib/data/tags.ts
+++ b/lib/data/tags.ts
@@ -1,0 +1,69 @@
+import { createClient } from "@/lib/supabase/server";
+import { Tag } from "@/lib/definitions";
+import { unstable_noStore as noStore } from "next/cache";
+
+// 全てのタグを取得（ユーザーIDで制限）
+export const getAllTags = async (userId: string): Promise<Tag[]> => {
+  noStore();
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("tags")
+    .select("*")
+    .eq("user_id", userId)
+    .order("name", { ascending: true });
+
+  if (error) {
+    console.error("Error fetching tags:", error);
+    throw new Error("Failed to fetch tags.");
+  }
+
+  return data || [];
+};
+
+// 新しいタグを作成
+export const createTag = async (name: string, userId: string): Promise<Tag> => {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("tags")
+    .insert({ name, user_id: userId })
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Error creating tag:", error);
+    throw new Error("Failed to create tag.");
+  }
+  return data;
+};
+
+// タグを削除
+export const deleteTag = async (tagId: string): Promise<void> => {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("tags")
+    .delete()
+    .eq("id", tagId);
+
+  if (error) {
+    console.error("Error deleting tag:", error);
+    throw new Error("Failed to delete tag.");
+  }
+};
+
+// タグを更新
+export const updateTag = async (tagId: string, name: string): Promise<Tag> => {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("tags")
+    .update({ name })
+    .eq("id", tagId)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Error updating tag:", error);
+    throw new Error("Failed to update tag.");
+  }
+
+  return data;
+};

--- a/lib/data/taskTags.ts
+++ b/lib/data/taskTags.ts
@@ -1,0 +1,77 @@
+import { createClient } from "@/lib/supabase/server";
+import { Tag } from "@/lib/definitions";
+import { unstable_noStore as noStore } from "next/cache";
+
+// タスクIDに紐づくタグ一覧を取得
+export const getTagsByTaskId = async (taskId: string): Promise<Tag[]> => {
+  noStore();
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("task_tags")
+    .select(`
+      tags (
+        id,
+        name,
+        user_id,
+        created_at,
+        updated_at
+      )
+    `)
+    .eq("task_id", taskId);
+
+  if (error) {
+    console.error("Error fetching tags by task ID:", error);
+    throw new Error("Failed to fetch tags.");
+  }
+
+return (
+  data
+    ?.flatMap(item => item.tags || [])
+  || []
+);
+};
+
+// タスクにタグを追加
+export const addTagToTask = async (taskId: string, tagId: string): Promise<void> => {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("task_tags")
+    .insert({
+      task_id: taskId,
+      tag_id: tagId
+    });
+
+  if (error) {
+    console.error("Error adding tag to task:", error);
+    throw new Error("Failed to add tag to task.");
+  }
+};
+
+// タスクからタグを削除
+export const removeTagFromTask = async (taskId: string, tagId: string): Promise<void> => {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("task_tags")
+    .delete()
+    .eq("task_id", taskId)
+    .eq("tag_id", tagId);
+
+  if (error) {
+    console.error("Error removing tag from task:", error);
+    throw new Error("Failed to remove tag from task.");
+  }
+};
+
+// タスクの全タグを削除
+export const removeAllTagsFromTask = async (taskId: string): Promise<void> => {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("task_tags")
+    .delete()
+    .eq("task_id", taskId);
+
+  if (error) {
+    console.error("Error removing all tags from task:", error);
+    throw new Error("Failed to remove all tags from task.");
+  }
+};

--- a/lib/data/tasks.ts
+++ b/lib/data/tasks.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
-import { Task } from "@/lib/definitions";
+import { Task, TaskWithTags } from "@/lib/definitions";
 
 export async function getTasksByUserId(userId: string): Promise<Task[]> {
   const supabase = await createClient();
@@ -16,6 +16,55 @@ export async function getTasksByUserId(userId: string): Promise<Task[]> {
   }
 
   return data || [];
+}
+
+export async function getTasksWithTagsByUserId(userId: string): Promise<TaskWithTags[]> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("tasks")
+    .select(`
+      *,
+      task_tags (
+        tags (
+          id,
+          name,
+          user_id,
+          created_at,
+          updated_at
+        )
+      )
+    `)
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Error fetching tasks with tags:", error);
+    throw new Error("Failed to fetch tasks with tags.");
+  }
+
+  // Define TaskTagRelation type if not imported
+  type TaskTagRelation = {
+    tags: {
+      id: string;
+      name: string;
+      user_id: string;
+      created_at: string;
+      updated_at: string;
+    };
+  };
+
+  type SupabaseTaskRow = Omit<TaskWithTags, "tags"> & {
+    task_tags?: TaskTagRelation[];
+  };
+
+  return (data as SupabaseTaskRow[] | null)?.map(task => {
+    const { task_tags, ...taskBase } = task;
+    return {
+      ...taskBase,
+      tags: (task_tags ?? []).map((tt) => tt.tags).filter(Boolean)
+    };
+  }) || [];
 }
 
 export async function getTaskById(taskId: string): Promise<Task | null> {

--- a/lib/definitions.ts
+++ b/lib/definitions.ts
@@ -56,3 +56,23 @@ export type CommentWithProfile = Comment & {
     name: string | null;
   };
 };
+
+export type Tag = {
+  id: string;
+  name: string;
+  user_id: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type TaskTag = {
+  id: string;
+  task_id: string;
+  tag_id: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type TaskWithTags = Task & {
+  tags?: Tag[];
+};


### PR DESCRIPTION
. タスクとタグのリレーション取得機能の追加
[getTasksWithTagsByUserId](vscode-file://vscode-app/private/var/folders/8n/p85mk1md5v35rqvhhrrf79640000gn/T/AppTranslocation/39624080-6770-4D25-906A-C85F78D9DD9D/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) 関数を [tasks.ts](vscode-file://vscode-app/private/var/folders/8n/p85mk1md5v35rqvhhrrf79640000gn/T/AppTranslocation/39624080-6770-4D25-906A-C85F78D9DD9D/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) に追加。
タスク一覧取得時に、各タスクに紐づくタグ情報（[task_tags](vscode-file://vscode-app/private/var/folders/8n/p85mk1md5v35rqvhhrrf79640000gn/T/AppTranslocation/39624080-6770-4D25-906A-C85F78D9DD9D/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)経由で[tags](vscode-file://vscode-app/private/var/folders/8n/p85mk1md5v35rqvhhrrf79640000gn/T/AppTranslocation/39624080-6770-4D25-906A-C85F78D9DD9D/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)）も同時に取得するように。
Supabaseのリレーション（[select](vscode-file://vscode-app/private/var/folders/8n/p85mk1md5v35rqvhhrrf79640000gn/T/AppTranslocation/39624080-6770-4D25-906A-C85F78D9DD9D/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)のネスト）を利用し、[task_tags(tags(...))](vscode-file://vscode-app/private/var/folders/8n/p85mk1md5v35rqvhhrrf79640000gn/T/AppTranslocation/39624080-6770-4D25-906A-C85F78D9DD9D/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) でタグ情報を取得。
取得したデータを [TaskWithTags](vscode-file://vscode-app/private/var/folders/8n/p85mk1md5v35rqvhhrrf79640000gn/T/AppTranslocation/39624080-6770-4D25-906A-C85F78D9DD9D/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) 型に整形して返すロジックを追加。
2. 型定義の追加・整理
[TaskTagRelation](vscode-file://vscode-app/private/var/folders/8n/p85mk1md5v35rqvhhrrf79640000gn/T/AppTranslocation/39624080-6770-4D25-906A-C85F78D9DD9D/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) 型（[task_tags](vscode-file://vscode-app/private/var/folders/8n/p85mk1md5v35rqvhhrrf79640000gn/T/AppTranslocation/39624080-6770-4D25-906A-C85F78D9DD9D/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)の中身）をローカルで定義。
Supabaseから取得したデータを [SupabaseTaskRow](vscode-file://vscode-app/private/var/folders/8n/p85mk1md5v35rqvhhrrf79640000gn/T/AppTranslocation/39624080-6770-4D25-906A-C85F78D9DD9D/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) 型で受け、[TaskWithTags](vscode-file://vscode-app/private/var/folders/8n/p85mk1md5v35rqvhhrrf79640000gn/T/AppTranslocation/39624080-6770-4D25-906A-C85F78D9DD9D/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) 型にマッピング。
3. 既存関数への影響なし
既存の [getTasksByUserId](vscode-file://vscode-app/private/var/folders/8n/p85mk1md5v35rqvhhrrf79640000gn/T/AppTranslocation/39624080-6770-4D25-906A-C85F78D9DD9D/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) や [getTaskById](vscode-file://vscode-app/private/var/folders/8n/p85mk1md5v35rqvhhrrf79640000gn/T/AppTranslocation/39624080-6770-4D25-906A-C85F78D9DD9D/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) には変更なし。
新たに「タスク＋タグ一覧」を取得する用途で [getTasksWithTagsByUserId](vscode-file://vscode-app/private/var/folders/8n/p85mk1md5v35rqvhhrrf79640000gn/T/AppTranslocation/39624080-6770-4D25-906A-C85F78D9DD9D/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) を追加。